### PR TITLE
add nodl ss58 prefix

### DIFF
--- a/lib/ss58/index.js
+++ b/lib/ss58/index.js
@@ -21,7 +21,7 @@ import bs58 from 'bs58';
 import { blake2b } from 'blakejs/blake2b';
 
 let defaultType = 42
-const KNOWN_TYPES = [0, 1, 2, 42, 43, 68, 69];
+const KNOWN_TYPES = [0, 1, 2, 37, 42, 43, 68, 69];
 
 const PREFIX = stringToBytes('SS58PRE');
 


### PR DESCRIPTION
Add prefix `37` to the list of known prefixes for ss58 decoding in order to support [`nodl`](https://nodle.com).